### PR TITLE
Update sbt-trickle to 0.2.4

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -3,7 +3,7 @@ libraryDependencies += "org.yaml" % "snakeyaml" % "1.26"
 addSbtPlugin("io.crashbox"       % "sbt-gpg"            % "0.2.1")
 addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.1-58d9629")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.4.0")
-addSbtPlugin("com.dcsobral"      % "sbt-trickle"        % "0.2.3")
+addSbtPlugin("com.dcsobral"      % "sbt-trickle"        % "0.2.4")
 
 libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-effect" % "2.1.2",


### PR DESCRIPTION
* Resolve artifacts transitively, by default
* trickleLogUpdatableRepositories
* trickleSaveGraph <filename.dot>
* trickleOpenGraph (requires graphviz)
* Working dry mode
* Github PR pagination
* trickleGitReset
* trickle{Outdated,Update,UpdateSession}Dependencies
* Better logging
* Less bugs