### PR TITLE
Revised slamx PRs to only auto-label if revision

### DIFF
--- a/core/src/test/scala/precog/AutoBumpObjectSpec.scala
+++ b/core/src/test/scala/precog/AutoBumpObjectSpec.scala
@@ -107,7 +107,7 @@ class AutoBumpObjectSpec(params: CommandLine) extends Specification with org.spe
           |""".stripMargin.split('\n').toList
       val label = extractLabel(lines)
 
-      label must beRight(ChangeLabel.Revision)
+      label must beSome(ChangeLabel.Revision)
     }
 
     "return ChangeLabel.Feature" in {
@@ -127,7 +127,7 @@ class AutoBumpObjectSpec(params: CommandLine) extends Specification with org.spe
           |""".stripMargin.split('\n').toList
       val label = extractLabel(lines)
 
-      label must beRight(ChangeLabel.Feature)
+      label must beSome(ChangeLabel.Feature)
     }
 
     "return ChangeLabel.Breaking" in {
@@ -147,7 +147,7 @@ class AutoBumpObjectSpec(params: CommandLine) extends Specification with org.spe
           |""".stripMargin.split('\n').toList
       val label = extractLabel(lines)
 
-      label must beRight(ChangeLabel.Breaking)
+      label must beSome(ChangeLabel.Breaking)
     }
 
     "warn if no label exists" in {
@@ -172,7 +172,7 @@ class AutoBumpObjectSpec(params: CommandLine) extends Specification with org.spe
 
       val label = extractLabel(lines)
 
-      label must beLeft(Warnings.NoLabel)
+      label must beNone
     }
   }
 

--- a/core/src/test/scala/precog/AutoBumpSpec.scala
+++ b/core/src/test/scala/precog/AutoBumpSpec.scala
@@ -211,9 +211,7 @@ class AutoBumpSpec(params: CommandLine) extends Specification with ScalaCheck wi
       val env = TestEnv.empty
       val tryUpdate = autobump.tryUpdateDependencies[Test](Runner.DefaultConfig)
 
-      val _ = tryUpdate.runA(env).unsafeRunSync()
-
-      ok    // ?
+      tryUpdate.runA(env).unsafeRunSync().label must beNone
     }
 
     "fetch all branches when cloning" in {

--- a/core/src/test/scala/precog/SbtPrecogBaseSpec.scala
+++ b/core/src/test/scala/precog/SbtPrecogBaseSpec.scala
@@ -161,7 +161,7 @@ class SbtPrecogBaseSpec(params: CommandLine) extends Specification {
 
     "log 'version: revision' for slamx" in {
       val versions = ManagedVersions(tmpdir.resolve("slamx.json"))
-      val mud = ModuleUpdateData(module, dep, "3.0.0", repo, url)
+      val mud = ModuleUpdateData(module, dep, "2.3.7", repo, url)
       val logger = TestLogger()
 
       versions.update(repo, version)
@@ -170,6 +170,28 @@ class SbtPrecogBaseSpec(params: CommandLine) extends Specification {
       logger.logs(Level.Info) must contain("version: revision")
       logger.logs(Level.Info) must not(contain("version: feature"))
       logger.logs(Level.Info) must not(contain("version: breaking"))
+    }
+
+    "log nothing for slamx when feature" in {
+      val versions = ManagedVersions(tmpdir.resolve("slamx.json"))
+      val mud = ModuleUpdateData(module, dep, "2.4.0", repo, url)
+      val logger = TestLogger()
+
+      versions.update(repo, version)
+      base.updateDependencies("precog-slamx", Set(mud), versions, logger)
+
+      logger.logs(Level.Info) must not(contain("version: "))
+    }
+
+    "log nothing for slamx when breaking" in {
+      val versions = ManagedVersions(tmpdir.resolve("slamx.json"))
+      val mud = ModuleUpdateData(module, dep, "3.0.0", repo, url)
+      val logger = TestLogger()
+
+      versions.update(repo, version)
+      base.updateDependencies("precog-slamx", Set(mud), versions, logger)
+
+      logger.logs(Level.Info) must not(contain("version: "))
     }
   }
 


### PR DESCRIPTION
The situation this is addressing is where sdbe has a **breaking** change. This will result in an autobump on slamx. We generally want such a bump to be a **revision** (not always though), but more importantly, we *don't* want that bump to automatically merge itself since it's probably breaking some things.

So the solution here is to remove the automatic feature label when it *isn't* a revision. Most things coming up from sdbe will still be revision, so we're not inconveniencing ourselves too much, but we avoid creating bad situations.