### PR TITLE
Stop publishing to bintray

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/backport/v'))
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/backport/v') || github.ref == 'refs/heads/master')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 description := "Common build configuration for SBT projects"
 
-ThisBuild / sbtVersion := "1.3.8"
+ThisBuild / sbtVersion := "1.3.13"
 ThisBuild / scalaVersion := "2.12.12"
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,10 @@ description := "Common build configuration for SBT projects"
 ThisBuild / sbtVersion := "1.3.13"
 ThisBuild / scalaVersion := "2.12.12"
 
+ThisBuild / githubOwner := "precog"
+ThisBuild / githubRepository := "sbt-precog"
+ThisBuild / githubTokenSource := TokenSource.Environment("GITHUB_TOKEN")
+
 lazy val root = project
   .in(file("."))
   .aggregate(core, artifact, plugin)

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.yaml" % "snakeyaml" % "1.26"
 
 addSbtPlugin("io.crashbox"       % "sbt-gpg"            % "0.2.1")
-addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.9.5")
+addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.10.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.0")
 addSbtPlugin("com.dcsobral"      % "sbt-trickle"        % "0.3-8f135be")
 

--- a/core/src/main/resources/core/publishAndTag
+++ b/core/src/main/resources/core/publishAndTag
@@ -24,12 +24,7 @@ fi
 
 openssl aes-256-cbc -md sha1 -pass env:ENCRYPTION_PASSWORD -in signing-secret.pgp.enc -d | gpg --import
 
-# plugins are published to bintray, while artifacts are published to github
-if $SBT 'show sbtPlugin' | grep true; then
-  "$SBT" bintrayEnsureBintrayPackageExists publish bintrayRelease "$TRICKLE_TASKS"
-else
-  "$SBT" +publish "$TRICKLE_TASKS"
-fi
+"$SBT" +publish "$TRICKLE_TASKS"
 
 HEAD_SHA=$(git rev-parse HEAD)
 TAG=v$VERSION

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -520,13 +520,6 @@ abstract class SbtPrecogBase extends AutoPlugin {
         update.value
       },
 
-      resolvers ++= {
-        if (!publishAsOSSProject.value)
-          Seq(Resolver.bintrayRepo("precog-inc", "maven-private"))
-        else
-          Seq.empty
-      },
-
       // TODO: self-check, to run on PRs
       // TODO: cluster datasources/destinations
 

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -248,7 +248,9 @@ abstract class SbtPrecogBase extends AutoPlugin {
           List(s"./scripts/publishAndTag $${{ github.repository }}"),
           name = Some("Publish artifacts and create tag"))),
 
-      githubWorkflowPublishTargetBranches += RefPredicate.StartsWith(Ref.Branch("backport/v")),
+      githubWorkflowPublishTargetBranches ++= Seq(
+        RefPredicate.StartsWith(Ref.Branch("backport/v")),
+        RefPredicate.Equals(Ref.Branch("master"))),
 
       githubWorkflowAddedJobs += WorkflowJob(
         "auto-merge",

--- a/plugin/build.sbt
+++ b/plugin/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
+addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.2")

--- a/plugin/src/main/scala/precog/SbtPrecogPlugin.scala
+++ b/plugin/src/main/scala/precog/SbtPrecogPlugin.scala
@@ -18,8 +18,6 @@ package precog
 
 import sbt._, Keys._
 
-import bintray.{BintrayKeys, BintrayPlugin}, BintrayKeys._
-
 import sbtghactions.GitHubActionsPlugin, GitHubActionsPlugin.autoImport._
 
 import scala.{sys, Some}
@@ -27,46 +25,25 @@ import scala.collection.immutable.Seq
 
 object SbtPrecogPlugin extends SbtPrecogBase {
 
-  override def requires = super.requires && BintrayPlugin
+  override def requires = super.requires
 
   object autoImport extends autoImport {
 
     lazy val noPublishSettings = Seq(
       publish := {},
       publishLocal := {},
-      bintrayRelease := {},
       publishArtifact := false,
-      skip in publish := true,
-      bintrayEnsureBintrayPackageExists := {})
+      skip in publish := true)
   }
 
   import autoImport._
 
   override def projectSettings =
     super.projectSettings ++
-    addCommandAlias("releaseSnapshot", "; project /; reload; checkLocalEvictions; bintrayEnsureBintrayPackageExists; publish; bintrayRelease") ++
+    addCommandAlias("releaseSnapshot", "; project /; reload; checkLocalEvictions; publish") ++
     Seq(
       sbtPlugin := true,
-
-      bintrayOrganization := Some("precog-bot"),
-      bintrayRepository := "sbt-plugins",
-      bintrayReleaseOnPublish := false,
-
-      publishMavenStyle := false,
-
-      // it's annoying that sbt-bintray doesn't do this for us
-      credentials ++= {
-        if (githubIsWorkflowBuild.value) {
-          val creds = for {
-            user <- sys.env.get("BINTRAY_USER")
-            pass <- sys.env.get("BINTRAY_PASS")
-          } yield Credentials("Bintray API Realm", "api.bintray.com", user, pass)
-
-          creds.toSeq
-        } else {
-          Seq()
-        }
-      })
+      publishMavenStyle := true)
 
   override def buildSettings =
     super.buildSettings ++

--- a/plugin/src/main/scala/precog/SbtPrecogPlugin.scala
+++ b/plugin/src/main/scala/precog/SbtPrecogPlugin.scala
@@ -18,9 +18,6 @@ package precog
 
 import sbt._, Keys._
 
-import sbtghactions.GitHubActionsPlugin, GitHubActionsPlugin.autoImport._
-
-import scala.{sys, Some}
 import scala.collection.immutable.Seq
 
 object SbtPrecogPlugin extends SbtPrecogBase {

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
 ThisBuild / scalaVersion := "2.12.12"
 
-addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.0" cross CrossVersion.full)
+addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.3" cross CrossVersion.full)
 addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")


### PR DESCRIPTION
Stop publishing to bintray completely. SBT plugins were still publishing to bintray, they are now publishing to GH packages instead.

Also upgrade to latest `sbt-github-actions` and bump some other deps.