### PR TITLE
Bump kind-projector to latest version that supports 2.12 and 2.13

### DIFF
--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -143,7 +143,7 @@ abstract class SbtPrecogBase extends AutoPlugin {
       autoCompilerPlugins := true,
       autoAPIMappings := true,
 
-      addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.0" cross CrossVersion.full),
+      addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.13.0" cross CrossVersion.full),
       addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
 
       // default to true


### PR DESCRIPTION
This allows using `sbt-precog` with Scala 2.13.6 and Scala 2.12.12. The downside is that this removed support for using `?` to define type lambdas. So if anyone wants to update to this version of `sbt-precog` they'll need to update all their type lambdas, hence `breaking`.