### PR TITLE
Made precog-bot the co-author of version bump commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build:
     name: Build and Test
-    if: '!(github.event_name == ''pull_request'' && github.event.pull_request.draft)'
+    if: '!(github.event_name == ''pull_request'' && github.event.pull_request.draft) && !(github.event_name == ''push'' && (github.ref == ''refs/heads/main'' || github.ref == ''refs/heads/master'') && !startsWith(github.commits[0].message, ''Version release''))'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -227,12 +227,7 @@ jobs:
               // set outputs for 
               const result = {
                 nextVersion: nextVersion,
-                commitMessage: "Version release: " + nextVersion + "
-
-            " + pr.title + "
-            " + pr.body.replaceAll("
-            ", "
-            ")
+                commitMessage: "Version release: " + nextVersion + "\n\n" + pr.title + "\n" + pr.body.replaceAll("\r\n", "\n")
               }
               return result
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,11 @@ jobs:
     steps:
       - name: Checkout current branch (fast)
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PRECOG_GITHUB_TOKEN }}
+
+      - name: Checkout current branch (fast)
+        uses: actions/checkout@v3
 
       - name: Get current version
         id: current_version
@@ -173,8 +178,7 @@ jobs:
               var patch = Number(parsedVersion[2])
 
               const prResponse = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                // owner: context.repo.owner,
-                owner: "precog",
+                owner: context.repo.owner,
                 repo: context.repo.repo,
                 commit_sha: context.sha
               })
@@ -227,15 +231,13 @@ jobs:
               }
               return result
 
-      - name: Commit set up
-        id: commit_set_up
-        run: |
-          echo "ThisBuild / version := $(echo '${{steps.compute_next_version.outputs.result}}' | jq '.nextVersion')" > version.sbt
-          echo "COMMIT_MESSAGE=$(echo '${{steps.compute_next_version.outputs.result}}' | jq '.commitMessage')" >> $GITHUB_OUTPUT
+      - name: Modify version
+        id: modify_version
+        run: 'echo ''ThisBuild / version := "${{fromJson(steps.compute_next_version.outputs.result).nextVersion}}"'' > version.sbt'
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: ${{steps.commit_set_up.outputs.COMMIT_MESSAGE}}
+          commit_message: ${{fromJson(steps.compute_next_version.outputs.result).commitMessage}}
           commit_user_name: precog-bot
           commit_user_email: bot@precog.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
 
   next-version:
     name: Next version
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !startsWith(github.commits[0].message, 'Version release')
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -237,3 +237,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: ${{steps.commit_set_up.outputs.COMMIT_MESSAGE}}
+          commit_user_name: precog-bot
+          commit_user_email: bot@precog.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,12 @@ jobs:
               // set outputs for 
               const result = {
                 nextVersion: nextVersion,
-                commitMessage: "Version release: " + nextVersion + "\n" + pr.body.replaceAll("\r\n", "\n")
+                commitMessage: "Version release: " + nextVersion + "
+
+            " + pr.title + "
+            " + pr.body.replaceAll("
+            ", "
+            ")
               }
               return result
 

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -242,6 +242,17 @@ abstract class SbtPrecogBase extends AutoPlugin {
         "next-version",
         "Next version",
         List(
+          // We have to replicate the checkout step ourselves to add the token to 
+          // overcome the github limitation of commmits triggered by workflows
+          // not triggerring additional workflows
+          // https://github.com/marketplace/actions/git-auto-commit#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+          WorkflowStep.Use(
+            UseRef.Public("actions", "checkout", "v3"), 
+            name = Some("Checkout current branch (fast)"),
+            params = Map(
+              "token" -> s"$${{ secrets.PRECOG_GITHUB_TOKEN }}"
+            )
+          ),
           WorkflowStep.Checkout,
           // Get current version
           WorkflowStep.Run(

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -242,12 +242,12 @@ abstract class SbtPrecogBase extends AutoPlugin {
         "next-version",
         "Next version",
         List(
-          // We have to replicate the checkout step ourselves to add the token to 
+          // We have to replicate the checkout step ourselves to add the token to
           // overcome the github limitation of commmits triggered by workflows
           // not triggerring additional workflows
           // https://github.com/marketplace/actions/git-auto-commit#commits-made-by-this-action-do-not-trigger-new-workflow-runs
           WorkflowStep.Use(
-            UseRef.Public("actions", "checkout", "v3"), 
+            UseRef.Public("actions", "checkout", "v3"),
             name = Some("Checkout current branch (fast)"),
             params = Map(
               "token" -> s"$${{ secrets.PRECOG_GITHUB_TOKEN }}"
@@ -333,7 +333,7 @@ abstract class SbtPrecogBase extends AutoPlugin {
             name = Some("Modify version"),
             id = Some("modify_version"),
             commands = List(
-              s"""echo 'ThisBuild / version := "$${{fromJson(steps.compute_next_version.outputs.result).nextVersion}}"' > version.sbt""",
+              s"""echo 'ThisBuild / version := "$${{fromJson(steps.compute_next_version.outputs.result).nextVersion}}"' > version.sbt"""
             )
           ),
           WorkflowStep.Use(
@@ -352,7 +352,8 @@ abstract class SbtPrecogBase extends AutoPlugin {
         //
         // Also, don't trigger a version bump on version bump commits or else we'll
         // just infinitely bump
-        cond = Some("github.event_name == 'push' && !startsWith(github.commits[0].message, 'Version release')")
+        cond = Some(
+          "github.event_name == 'push' && !startsWith(github.commits[0].message, 'Version release')")
       ),
       githubWorkflowPublishCond ~= { condMaybe =>
         val extraCondition = """startsWith(github.commits[0].message, 'Version release')"""

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -324,7 +324,7 @@ abstract class SbtPrecogBase extends AutoPlugin {
                              |  // set outputs for 
                              |  const result = {
                              |    nextVersion: nextVersion,
-                             |    commitMessage: "Version release: " + nextVersion + "\\n" + pr.body.replaceAll("\\r\\n", "\\n")
+                             |    commitMessage: "Version release: " + nextVersion + "\n\n" + pr.title + "\n" + pr.body.replaceAll("\r\n", "\n")
                              |  }
                              |  return result""".stripMargin
             )

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -264,8 +264,7 @@ abstract class SbtPrecogBase extends AutoPlugin {
                              |  var patch = Number(parsedVersion[2])
                              |
                              |  const prResponse = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                             |    // owner: context.repo.owner,
-                             |    owner: "precog",
+                             |    owner: context.repo.owner,
                              |    repo: context.repo.repo,
                              |    commit_sha: context.sha
                              |  })

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -331,14 +331,19 @@ abstract class SbtPrecogBase extends AutoPlugin {
             name = Some("Commit changes"),
             ref = UseRef.Public("stefanzweifel", "git-auto-commit-action", "v4"),
             params = Map(
-              "commit_message" -> s"$${{steps.commit_set_up.outputs.COMMIT_MESSAGE}}"
+              "commit_message" -> s"$${{steps.commit_set_up.outputs.COMMIT_MESSAGE}}",
+              "commit_user_name" -> "precog-bot",
+              "commit_user_email" -> "bot@precog.com"
             )
           )
         ),
         // We check that it's a push. We don't need to check for whether the branch
         // is right because the whole workflow is set to only run on either pull requests or
         // pushes to main/master, so a check that it's a push is enough
-        cond = Some("github.event_name == 'push'")
+        //
+        // Also, don't trigger a version bump on version bump commits or else we'll
+        // just infinitely bump
+        cond = Some("github.event_name == 'push' && !startsWith(github.commits[0].message, 'Version release')")
       ),
       githubWorkflowPublishCond ~= { condMaybe =>
         val extraCondition = """startsWith(github.commits[0].message, 'Version release')"""

--- a/core/src/main/scala/precog/SbtPrecogBase.scala
+++ b/core/src/main/scala/precog/SbtPrecogBase.scala
@@ -330,18 +330,17 @@ abstract class SbtPrecogBase extends AutoPlugin {
             )
           ),
           WorkflowStep.Run(
-            name = Some("Commit set up"),
-            id = Some("commit_set_up"),
+            name = Some("Modify version"),
+            id = Some("modify_version"),
             commands = List(
-              s"""echo "ThisBuild / version := $$(echo '$${{steps.compute_next_version.outputs.result}}' | jq '.nextVersion')" > version.sbt""",
-              s"""echo \"COMMIT_MESSAGE=$$(echo '$${{steps.compute_next_version.outputs.result}}' | jq '.commitMessage')\" >> $$GITHUB_OUTPUT"""
+              s"""echo 'ThisBuild / version := "$${{fromJson(steps.compute_next_version.outputs.result).nextVersion}}"' > version.sbt""",
             )
           ),
           WorkflowStep.Use(
             name = Some("Commit changes"),
             ref = UseRef.Public("stefanzweifel", "git-auto-commit-action", "v4"),
             params = Map(
-              "commit_message" -> s"$${{steps.commit_set_up.outputs.COMMIT_MESSAGE}}",
+              "commit_message" -> s"$${{fromJson(steps.compute_next_version.outputs.result).commitMessage}}",
               "commit_user_name" -> "precog-bot",
               "commit_user_email" -> "bot@precog.com"
             )


### PR DESCRIPTION
Fixes https://github.com/precog/devtools/issues/50
Continuation of https://github.com/precog/sbt-precog/pull/133

This PR aims to finish off this feature with the following:

- [x] fix newlines in the commit string
- [x] run CI on the auto-committed commit
- [x] avoid running `build` on commits which will result in a version increment
- [x] don't infinitely loop with version bumps